### PR TITLE
docs: change link to OmniSafeAI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Please do your best to make the issue as easy to act on as possible, and only submit here if there is clearly a problem with OmniSafe (ask in [Discussions](https://github.com/PKU-MARL/omnisafe/discussions) first if unsure).
+        Please do your best to make the issue as easy to act on as possible, and only submit here if there is clearly a problem with OmniSafe (ask in [Discussions](https://github.com/OmniSafeAI/omnisafe/discussions) first if unsure).
 
   - type: checkboxes
     id: steps
@@ -17,9 +17,9 @@ body:
       options:
         - label: I have read the documentation <https://omnisafe.readthedocs.io>.
           required: true
-        - label: I have searched the [Issue Tracker](https://github.com/PKU-MARL/omnisafe/issues) and [Discussions](https://github.com/PKU-MARL/omnisafe/discussions) that this hasn't already been reported. (+1 or comment there if it has.)
+        - label: I have searched the [Issue Tracker](https://github.com/OmniSafeAI/omnisafe/issues) and [Discussions](https://github.com/OmniSafeAI/omnisafe/discussions) that this hasn't already been reported. (+1 or comment there if it has.)
           required: true
-        - label: Consider asking first in a [Discussion](https://github.com/PKU-MARL/omnisafe/discussions/new).
+        - label: Consider asking first in a [Discussion](https://github.com/OmniSafeAI/omnisafe/discussions/new).
           required: false
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Start a discussion
-    url: https://github.com/PKU-MARL/omnisafe/discussions/new
+    url: https://github.com/OmniSafeAI/omnisafe/discussions/new
     about: Please ask and answer questions here if unsure.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -9,9 +9,9 @@ body:
       label: Required prerequisites
       description: Make sure you've completed the following steps before submitting your issue -- thank you!
       options:
-        - label: I have searched the [Issue Tracker](https://github.com/PKU-MARL/omnisafe/issues) and [Discussions](https://github.com/PKU-MARL/omnisafe/discussions) that this hasn't already been reported. (+1 or comment there if it has.)
+        - label: I have searched the [Issue Tracker](https://github.com/OmniSafeAI/omnisafe/issues) and [Discussions](https://github.com/OmniSafeAI/omnisafe/discussions) that this hasn't already been reported. (+1 or comment there if it has.)
           required: true
-        - label: Consider asking first in a [Discussion](https://github.com/PKU-MARL/omnisafe/discussions/new).
+        - label: Consider asking first in a [Discussion](https://github.com/OmniSafeAI/omnisafe/discussions/new).
           required: false
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/questions.yml
+++ b/.github/ISSUE_TEMPLATE/questions.yml
@@ -11,9 +11,9 @@ body:
       options:
         - label: I have read the documentation <https://omnisafe.readthedocs.io>.
           required: true
-        - label: I have searched the [Issue Tracker](https://github.com/PKU-MARL/omnisafe/issues) and [Discussions](https://github.com/PKU-MARL/omnisafe/discussions) that this hasn't already been reported. (+1 or comment there if it has.)
+        - label: I have searched the [Issue Tracker](https://github.com/OmniSafeAI/omnisafe/issues) and [Discussions](https://github.com/OmniSafeAI/omnisafe/discussions) that this hasn't already been reported. (+1 or comment there if it has.)
           required: true
-        - label: Consider asking first in a [Discussion](https://github.com/PKU-MARL/omnisafe/discussions/new).
+        - label: Consider asking first in a [Discussion](https://github.com/OmniSafeAI/omnisafe/discussions/new).
           required: false
 
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
 You can use the syntax `close #15213` if this solves the issue #15213
 
-- [ ] I have raised an issue to propose this change ([required](https://github.com/PKU-MARL/omnisafe/issues) for new features and bug fixes)
+- [ ] I have raised an issue to propose this change ([required](https://github.com/OmniSafeAI/omnisafe/issues) for new features and bug fixes)
 
 ## Types of changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Features
-- Feat: add `ruff` and `codespell` integration by [@XuehaiPan](https://github.com/XuehaiPan) in PR [#186](https://github.com/PKU-MARL/omnisafe/pull/186).
+- Feat: add `ruff` and `codespell` integration by [@XuehaiPan](https://github.com/XuehaiPan) in PR [#186](https://github.com/OmniSafeAI/omnisafe/pull/186).
 ### Fixes
 ### Documentation
 
@@ -17,161 +17,161 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v0.2.2
 ### Fixes
-- Add MANIFEST.in by [@Borong Zhang](https://github.com/muchvo) in PR [#182](https://github.com/PKU-MARL/omnisafe/pull/182).
+- Add MANIFEST.in by [@Borong Zhang](https://github.com/muchvo) in PR [#182](https://github.com/OmniSafeAI/omnisafe/pull/182).
 ### Documentation
-- Update api documentation by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#181](https://github.com/PKU-MARL/omnisafe/pull/181)
+- Update api documentation by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#181](https://github.com/OmniSafeAI/omnisafe/pull/181)
 ## v0.2.1
 ### Features
-- Feat(statistics tools): support statistics tools for experiments by [@Borong Zhang](https://github.com/muchvo) in PR [#157](https://github.com/PKU-MARL/omnisafe/pull/157).
+- Feat(statistics tools): support statistics tools for experiments by [@Borong Zhang](https://github.com/muchvo) in PR [#157](https://github.com/OmniSafeAI/omnisafe/pull/157).
 ## v0.2.0
 ### Features
-- Support cuda by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#163](https://github.com/PKU-MARL/omnisafe/pull/163).
-- Support command line interfaces for omnisafe by [@Borong Zhang](https://github.com/muchvo) in PR [#144](https://github.com/PKU-MARL/omnisafe/pull/144).
-- Refactor(wrapper): refactor the cuda setting by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#176](https://github.com/PKU-MARL/omnisafe/pull/176).
+- Support cuda by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#163](https://github.com/OmniSafeAI/omnisafe/pull/163).
+- Support command line interfaces for omnisafe by [@Borong Zhang](https://github.com/muchvo) in PR [#144](https://github.com/OmniSafeAI/omnisafe/pull/144).
+- Refactor(wrapper): refactor the cuda setting by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#176](https://github.com/OmniSafeAI/omnisafe/pull/176).
 ### Fixes
-- Fix(onpolicy_adapter): fix the calculation of last state value by [@Borong Zhang](https://github.com/muchvo) in PR [#164](https://github.com/PKU-MARL/omnisafe/pull/164).
-- Fix(config.py): fix config assertion by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#174](https://github.com/PKU-MARL/omnisafe/pull/174).
-- Fix autoreset wrapper in by [@r-y1](https://github.com/r-y1) PR [#167](https://github.com/PKU-MARL/omnisafe/pull/167).
+- Fix(onpolicy_adapter): fix the calculation of last state value by [@Borong Zhang](https://github.com/muchvo) in PR [#164](https://github.com/OmniSafeAI/omnisafe/pull/164).
+- Fix(config.py): fix config assertion by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#174](https://github.com/OmniSafeAI/omnisafe/pull/174).
+- Fix autoreset wrapper in by [@r-y1](https://github.com/r-y1) PR [#167](https://github.com/OmniSafeAI/omnisafe/pull/167).
 ### Documentation
-- Update docs style by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#169](https://github.com/PKU-MARL/omnisafe/pull/169).
-- Fix typo in readme by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#172](https://github.com/PKU-MARL/omnisafe/pull/172).
-- Update README and the usage of CLI by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#138](https://github.com/PKU-MARL/omnisafe/pull/138).
+- Update docs style by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#169](https://github.com/OmniSafeAI/omnisafe/pull/169).
+- Fix typo in readme by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#172](https://github.com/OmniSafeAI/omnisafe/pull/172).
+- Update README and the usage of CLI by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#138](https://github.com/OmniSafeAI/omnisafe/pull/138).
 ## v0.1.0
 - Check out `Development` for more.
 ------
 ## Development
 ### 2023-03-06 ~ 2023-03-15
 #### Features
-- Chore(on-policy): update benchmark performance for first-order algorithms by [@Borong Zhang](https://github.com/muchvo) in PR [#148](https://github.com/PKU-MARL/omnisafe/pull/148).
-- Feat(off-policy): add DDPG, TD3 SAC by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#128](https://github.com/PKU-MARL/omnisafe/pull/128).
-- Feat: support policy evaluation by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#137](https://github.com/PKU-MARL/omnisafe/pull/137).
-- Test: add more test case, and fix bugs by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#136](https://github.com/PKU-MARL/omnisafe/pull/136).
-- Fix(logger, wrapper): support csv file and velocity tasks by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#131](https://github.com/PKU-MARL/omnisafe/pull/131).
-- Feat: update architecture of config.yaml by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#126](https://github.com/PKU-MARL/omnisafe/pull/126).
-- Chore: support num_thread setting by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#124](https://github.com/PKU-MARL/omnisafe/pull/124).
-- Refactor: change architecture of omnisafe by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#121](https://github.com/PKU-MARL/omnisafe/pull/121).
+- Chore(on-policy): update benchmark performance for first-order algorithms by [@Borong Zhang](https://github.com/muchvo) in PR [#148](https://github.com/OmniSafeAI/omnisafe/pull/148).
+- Feat(off-policy): add DDPG, TD3 SAC by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#128](https://github.com/OmniSafeAI/omnisafe/pull/128).
+- Feat: support policy evaluation by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#137](https://github.com/OmniSafeAI/omnisafe/pull/137).
+- Test: add more test case, and fix bugs by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#136](https://github.com/OmniSafeAI/omnisafe/pull/136).
+- Fix(logger, wrapper): support csv file and velocity tasks by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#131](https://github.com/OmniSafeAI/omnisafe/pull/131).
+- Feat: update architecture of config.yaml by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#126](https://github.com/OmniSafeAI/omnisafe/pull/126).
+- Chore: support num_thread setting by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#124](https://github.com/OmniSafeAI/omnisafe/pull/124).
+- Refactor: change architecture of omnisafe by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#121](https://github.com/OmniSafeAI/omnisafe/pull/121).
 #### Fixes
-- Fix(on-policy): fix the second order algorithms performance by [@Jiayi Zhou](https://github.com/Gaiejj)  in PR [#147](https://github.com/PKU-MARL/omnisafe/pull/147).
-- Fix(rollout, exp_grid): fix logdir path conflict by [@Borong Zhang](https://github.com/muchvo) in PR [#145](https://github.com/PKU-MARL/omnisafe/pull/145).
-- Fix: support new config for exp_grid by [@Borong Zhang](https://github.com/muchvo) in PR [#142](https://github.com/PKU-MARL/omnisafe/pull/142).
-- Fix(ppo): fix entropy loss by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#135](https://github.com/PKU-MARL/omnisafe/pull/135).
-- Fix(algo): fix no return in algo_wrapper::learn by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#122](https://github.com/PKU-MARL/omnisafe/pull/122).
+- Fix(on-policy): fix the second order algorithms performance by [@Jiayi Zhou](https://github.com/Gaiejj)  in PR [#147](https://github.com/OmniSafeAI/omnisafe/pull/147).
+- Fix(rollout, exp_grid): fix logdir path conflict by [@Borong Zhang](https://github.com/muchvo) in PR [#145](https://github.com/OmniSafeAI/omnisafe/pull/145).
+- Fix: support new config for exp_grid by [@Borong Zhang](https://github.com/muchvo) in PR [#142](https://github.com/OmniSafeAI/omnisafe/pull/142).
+- Fix(ppo): fix entropy loss by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#135](https://github.com/OmniSafeAI/omnisafe/pull/135).
+- Fix(algo): fix no return in algo_wrapper::learn by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#122](https://github.com/OmniSafeAI/omnisafe/pull/122).
 #### Documentation
 - Docs: Update changelog by [@Jiaming Ji](https://github.com/zmsn-2077).
-- Docs: Update README.md: fix action passing by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#149](https://github.com/PKU-MARL/omnisafe/pull/149).
-- Chore: fix typo by [@1Asan](https://github.com/1Asan) in PR [#134](https://github.com/PKU-MARL/omnisafe/pull/134).
+- Docs: Update README.md: fix action passing by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#149](https://github.com/OmniSafeAI/omnisafe/pull/149).
+- Chore: fix typo by [@1Asan](https://github.com/1Asan) in PR [#134](https://github.com/OmniSafeAI/omnisafe/pull/134).
 ### 2023-02-27 ~ 2023-03-05
 #### Fixes
-- Fix(P3O): fix P3O performance by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#123](https://github.com/PKU-MARL/omnisafe/pull/123).
-- Fix(off-policy): fix `action passing` by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#119](https://github.com/PKU-MARL/omnisafe/pull/119).
+- Fix(P3O): fix P3O performance by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#123](https://github.com/OmniSafeAI/omnisafe/pull/123).
+- Fix(off-policy): fix `action passing` by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#119](https://github.com/OmniSafeAI/omnisafe/pull/119).
 #### Documentation
-- Docs: update logo by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#125](https://github.com/PKU-MARL/omnisafe/pull/125).
+- Docs: update logo by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#125](https://github.com/OmniSafeAI/omnisafe/pull/125).
 
 ### 2023-02-13 ~ 2023-02-19
 #### Fixes
-- Fix(evaluator): fix evaluator by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#117](https://github.com/PKU-MARL/omnisafe/pull/117).
+- Fix(evaluator): fix evaluator by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#117](https://github.com/OmniSafeAI/omnisafe/pull/117).
 ### 2023-02-06 ~ 2023-02-12
 #### Features
-- Build(env): delete local `safety-gymnaisum` dependence by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#102](https://github.com/PKU-MARL/omnisafe/pull/102).
-- Refactor(buffer): refactor `buffer` by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#101](https://github.com/PKU-MARL/omnisafe/pull/101).
+- Build(env): delete local `safety-gymnaisum` dependence by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#102](https://github.com/OmniSafeAI/omnisafe/pull/102).
+- Refactor(buffer): refactor `buffer` by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#101](https://github.com/OmniSafeAI/omnisafe/pull/101).
 - Refactor: clean the code by [@Jiayi Zhou](https://github.com/Gaiejj) in
 #### Fixes
-- Fix: fix tools by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#100](https://github.com/PKU-MARL/omnisafe/pull/100).
-- Fix: fix algo wrapper by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#99](https://github.com/PKU-MARL/omnisafe/pull/99).
-PR [#97](https://github.com/PKU-MARL/omnisafe/pull/97).
+- Fix: fix tools by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#100](https://github.com/OmniSafeAI/omnisafe/pull/100).
+- Fix: fix algo wrapper by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#99](https://github.com/OmniSafeAI/omnisafe/pull/99).
+PR [#97](https://github.com/OmniSafeAI/omnisafe/pull/97).
 #### Documentation
-- Modify `logo.png` and add `requirements.txt` by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#103](https://github.com/PKU-MARL/omnisafe/pull/103).
+- Modify `logo.png` and add `requirements.txt` by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#103](https://github.com/OmniSafeAI/omnisafe/pull/103).
 
 
 ### 2023-01-30 ~ 2023-02-05
 #### Features
 - Chore: update linter settings by [@XuehaiPan](https://github.com/XuehaiPan).
-- Chore: update ci  by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#90](https://github.com/PKU-MARL/omnisafe/pull/90) reviewed by [@Jiaming Ji](https://github.com/zmsn-2077) and [@friedmainfunction](https://github.com/friedmainfunction).
-- Chore: update yaml  by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#92](https://github.com/PKU-MARL/omnisafe/pull/92) and [#93](https://github.com/PKU-MARL/omnisafe/pull/93) reviewed by [@Jiaming Ji](https://github.com/zmsn-2077) and [@friedmainfunction](https://github.com/friedmainfunction).
+- Chore: update ci  by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#90](https://github.com/OmniSafeAI/omnisafe/pull/90) reviewed by [@Jiaming Ji](https://github.com/zmsn-2077) and [@friedmainfunction](https://github.com/friedmainfunction).
+- Chore: update yaml  by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#92](https://github.com/OmniSafeAI/omnisafe/pull/92) and [#93](https://github.com/OmniSafeAI/omnisafe/pull/93) reviewed by [@Jiaming Ji](https://github.com/zmsn-2077) and [@friedmainfunction](https://github.com/friedmainfunction).
 ### 2023-01-23 ~ 2023-01-29
 #### Features
-- Refactor(objects): change object type into free_geom by [@Borong Zhang](https://github.com/muchvo) in PR [#89](https://github.com/PKU-MARL/omnisafe/pull/89).
-- Chore: update algorithms configuration by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#88](https://github.com/PKU-MARL/omnisafe/pull/88).
-- Feat: support cuda by [@Jiayi Zhou](https://github.com/Gaiejj in PR [#86](https://github.com/PKU-MARL/omnisafe/pull/86).
-- Feat(render): add keyboard debug mode for some agents in all tasks by [@Borong Zhang](https://github.com/muchvo) in PR [#83](https://github.com/PKU-MARL/omnisafe/pull/83).
-- Feat: add experiment grid by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#84](https://github.com/PKU-MARL/omnisafe/pull/84).
+- Refactor(objects): change object type into free_geom by [@Borong Zhang](https://github.com/muchvo) in PR [#89](https://github.com/OmniSafeAI/omnisafe/pull/89).
+- Chore: update algorithms configuration by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#88](https://github.com/OmniSafeAI/omnisafe/pull/88).
+- Feat: support cuda by [@Jiayi Zhou](https://github.com/Gaiejj in PR [#86](https://github.com/OmniSafeAI/omnisafe/pull/86).
+- Feat(render): add keyboard debug mode for some agents in all tasks by [@Borong Zhang](https://github.com/muchvo) in PR [#83](https://github.com/OmniSafeAI/omnisafe/pull/83).
+- Feat: add experiment grid by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#84](https://github.com/OmniSafeAI/omnisafe/pull/84).
 #### Fixes
-- Fix seed setting  by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#82](https://github.com/PKU-MARL/omnisafe/pull/82).
+- Fix seed setting  by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#82](https://github.com/OmniSafeAI/omnisafe/pull/82).
 
 
 ### 2023-01-16 ~ 2023-01-22
 #### Features
-- Feat(agents): add `ant` agent by [@Borong Zhang](https://github.com/muchvo) in PR [#82](https://github.com/PKU-MARL/omnisafe/pull/82).
-- Refactor(safety-gymnaisum): `code decoupling` by [@Borong Zhang](https://github.com/muchvo) in PR [#81](https://github.com/PKU-MARL/omnisafe/pull/81).
-- Feat: add new algorithm by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#80](https://github.com/PKU-MARL/omnisafe/pull/80).
+- Feat(agents): add `ant` agent by [@Borong Zhang](https://github.com/muchvo) in PR [#82](https://github.com/OmniSafeAI/omnisafe/pull/82).
+- Refactor(safety-gymnaisum): `code decoupling` by [@Borong Zhang](https://github.com/muchvo) in PR [#81](https://github.com/OmniSafeAI/omnisafe/pull/81).
+- Feat: add new algorithm by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#80](https://github.com/OmniSafeAI/omnisafe/pull/80).
 ### 2023-01-09 ~ 2023-01-15
 #### Features
-- Refactor: change wrapper setting by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#73](https://github.com/PKU-MARL/omnisafe/pull/73).
-- Feat: `vectorized` environment by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#74](https://github.com/PKU-MARL/omnisafe/pull/74).
+- Refactor: change wrapper setting by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#73](https://github.com/OmniSafeAI/omnisafe/pull/73).
+- Feat: `vectorized` environment by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#74](https://github.com/OmniSafeAI/omnisafe/pull/74).
 ### 2023-01-02 ~ 2023-01-08
 #### Features
-- Feat(agents, tasks, Evaluator): support `circle012` and new agent `racecar`, update evaluator by [@Borong Zhang](https://github.com/muchvo) in PR [#59](https://github.com/PKU-MARL/omnisafe/pull/59).
+- Feat(agents, tasks, Evaluator): support `circle012` and new agent `racecar`, update evaluator by [@Borong Zhang](https://github.com/muchvo) in PR [#59](https://github.com/OmniSafeAI/omnisafe/pull/59).
 
 ### 2022-12-26 ~ 2023-01-01
 #### Features
-- Refactor: enhanced model-based code, add `CAP` algorithm by [@Weidong Huang](https://github.com/hdadong) in PR [#59](https://github.com/PKU-MARL/omnisafe/pull/59).
-- Feat: support auto render as .mp4 videos, add examples and tests by [@Borong Zhang](https://github.com/muchvo) in PR [#60](https://github.com/PKU-MARL/omnisafe/pull/60).
+- Refactor: enhanced model-based code, add `CAP` algorithm by [@Weidong Huang](https://github.com/hdadong) in PR [#59](https://github.com/OmniSafeAI/omnisafe/pull/59).
+- Feat: support auto render as .mp4 videos, add examples and tests by [@Borong Zhang](https://github.com/muchvo) in PR [#60](https://github.com/OmniSafeAI/omnisafe/pull/60).
 #### Fixes
-- Fix(model-based): fix cap cost bug and lag beta value in cap.yaml by [@Weidong Huang](https://github.com/hdadong) in PR [#62](https://github.com/PKU-MARL/omnisafe/pull/62).
-- Fix(render): fix markers are not shown in the rgb array returned by env.render() by [@Borong Zhang](https://github.com/muchvo) in PR [#61](https://github.com/PKU-MARL/omnisafe/pull/61).
+- Fix(model-based): fix cap cost bug and lag beta value in cap.yaml by [@Weidong Huang](https://github.com/hdadong) in PR [#62](https://github.com/OmniSafeAI/omnisafe/pull/62).
+- Fix(render): fix markers are not shown in the rgb array returned by env.render() by [@Borong Zhang](https://github.com/muchvo) in PR [#61](https://github.com/OmniSafeAI/omnisafe/pull/61).
 
 
 
 ### 2022-12-19 ~ 2022-12-25
 #### Features
-- Feat(circle, run): support new tasks by [@Borong Zhang](https://github.com/muchvo) in PR [#50](https://github.com/PKU-MARL/omnisafe/pull/50).
-- Add Makefile by [@XuehaiPan](https://github.com/XuehaiPan) in PR [#53](https://github.com/PKU-MARL/omnisafe/pull/53).
+- Feat(circle, run): support new tasks by [@Borong Zhang](https://github.com/muchvo) in PR [#50](https://github.com/OmniSafeAI/omnisafe/pull/50).
+- Add Makefile by [@XuehaiPan](https://github.com/XuehaiPan) in PR [#53](https://github.com/OmniSafeAI/omnisafe/pull/53).
 #### Fixes
-- Fix bug for namedtuple by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#54](https://github.com/PKU-MARL/omnisafe/pull/54).
+- Fix bug for namedtuple by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#54](https://github.com/OmniSafeAI/omnisafe/pull/54).
 #### Documentation
-- Fix spelling error by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#56](https://github.com/PKU-MARL/omnisafe/pull/56), reviewed by [@Jiaming Ji](https://github.com/zmsn-2077) and [@XuehaiPan](https://github.com/XuehaiPan).
+- Fix spelling error by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#56](https://github.com/OmniSafeAI/omnisafe/pull/56), reviewed by [@Jiaming Ji](https://github.com/zmsn-2077) and [@XuehaiPan](https://github.com/XuehaiPan).
 
 
 ### 2022-12-12 ~ 2022-12-18
 #### Features
-- Refactor: open pylint in pre-commit by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#48](https://github.com/PKU-MARL/omnisafe/pull/48).
-- Refactor: change the details and yaml files of on policy algorithm by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#41](https://github.com/PKU-MARL/omnisafe/pull/41).
-- Feat: add CUP algorithm by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#43](https://github.com/PKU-MARL/omnisafe/pull/43).
-- Feat(wrapper): separated wrapper for different algorithmic environments by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#44](https://github.com/PKU-MARL/omnisafe/pull/44).
-- Chore: rename files and enable pylint by [@Borong Zhang](https://github.com/muchvo) in  PR [#39](https://github.com/PKU-MARL/omnisafe/pull/39).
+- Refactor: open pylint in pre-commit by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#48](https://github.com/OmniSafeAI/omnisafe/pull/48).
+- Refactor: change the details and yaml files of on policy algorithm by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#41](https://github.com/OmniSafeAI/omnisafe/pull/41).
+- Feat: add CUP algorithm by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#43](https://github.com/OmniSafeAI/omnisafe/pull/43).
+- Feat(wrapper): separated wrapper for different algorithmic environments by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#44](https://github.com/OmniSafeAI/omnisafe/pull/44).
+- Chore: rename files and enable pylint by [@Borong Zhang](https://github.com/muchvo) in  PR [#39](https://github.com/OmniSafeAI/omnisafe/pull/39).
 #### Documentation
-- Retouch the formatting and add PPO docs for omnisafe by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#40](https://github.com/PKU-MARL/omnisafe/pull/40).
-- Add Lagrangian method documentation by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#42](https://github.com/PKU-MARL/omnisafe/pull/42).
-- Refactor(README): show the implemented algorithms in more detail by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#47](https://github.com/PKU-MARL/omnisafe/pull/47).
+- Retouch the formatting and add PPO docs for omnisafe by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#40](https://github.com/OmniSafeAI/omnisafe/pull/40).
+- Add Lagrangian method documentation by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#42](https://github.com/OmniSafeAI/omnisafe/pull/42).
+- Refactor(README): show the implemented algorithms in more detail by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#47](https://github.com/OmniSafeAI/omnisafe/pull/47).
 ### 2022-12-05 ~ 2022-12-11
 #### Features
-- Refactor: more OOP style code were used and made better code and file structure by [@Borong Zhang](https://github.com/muchvo) in PR [#37](https://github.com/PKU-MARL/omnisafe/pull/37).
-- Refactor: change the file layout of omnisafe by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#35](https://github.com/PKU-MARL/omnisafe/pull/35).
+- Refactor: more OOP style code were used and made better code and file structure by [@Borong Zhang](https://github.com/muchvo) in PR [#37](https://github.com/OmniSafeAI/omnisafe/pull/37).
+- Refactor: change the file layout of omnisafe by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#35](https://github.com/OmniSafeAI/omnisafe/pull/35).
 #### Fixes
-- Fix(env_wrapper): fix warning caused by 'none' string default value by [@Borong Zhang](https://github.com/muchvo) in PR [#30](https://github.com/PKU-MARL/omnisafe/pull/30).
+- Fix(env_wrapper): fix warning caused by 'none' string default value by [@Borong Zhang](https://github.com/muchvo) in PR [#30](https://github.com/OmniSafeAI/omnisafe/pull/30).
 #### Documentation
-- Docs: retouch the formatting and add links to the formula numbers by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#31](https://github.com/PKU-MARL/omnisafe/pull/31).
+- Docs: retouch the formatting and add links to the formula numbers by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#31](https://github.com/OmniSafeAI/omnisafe/pull/31).
 ### 2022-11-28 ~ 2022-12-04
 #### Features
-- Chore(.github): update issue templates by [@XuehaiPan](https://github.com/XuehaiPan) in PR [#29](https://github.com/PKU-MARL/omnisafe/pull/29).
-- Refactor packaging by [@XuehaiPan](https://github.com/XuehaiPan) in PR [#20](https://github.com/PKU-MARL/omnisafe/pull/20).
-- Add ddpg, clean some code, modify algo_wrapper in PR [#24](https://github.com/PKU-MARL/omnisafe/pull/24) by [@Jiaming Ji](https://github.com/zmsn-2077).
+- Chore(.github): update issue templates by [@XuehaiPan](https://github.com/XuehaiPan) in PR [#29](https://github.com/OmniSafeAI/omnisafe/pull/29).
+- Refactor packaging by [@XuehaiPan](https://github.com/XuehaiPan) in PR [#20](https://github.com/OmniSafeAI/omnisafe/pull/20).
+- Add ddpg, clean some code, modify algo_wrapper in PR [#24](https://github.com/OmniSafeAI/omnisafe/pull/24) by [@Jiaming Ji](https://github.com/zmsn-2077).
 #### Documentation
-- Add `TRPO` to docs by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#28](https://github.com/PKU-MARL/omnisafe/pull/28).
-- Add `FOCOPS` and `PCPO` to docs by [@XuehaiPan](https://github.com/XuehaiPan) in [#21](https://github.com/PKU-MARL/omnisafe/pull/21).
+- Add `TRPO` to docs by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#28](https://github.com/OmniSafeAI/omnisafe/pull/28).
+- Add `FOCOPS` and `PCPO` to docs by [@XuehaiPan](https://github.com/XuehaiPan) in [#21](https://github.com/OmniSafeAI/omnisafe/pull/21).
 
 ### 2022-11-20 ~ 2022-11-27
 #### Features
 - Add render_mode: `human`, `rgb_array`, `depth_array` in safety-gymnasium: `safety_gym_v2`.
-- Add **Model-based Safe Algorithms:** `mbppolag`, `safeloop` by [@Weidong Huang](https://github.com/hdadong) in [#12](https://github.com/PKU-MARL/omnisafe/pull/12).
-- Add .editorconfig and update license by [@XuehaiPan](https://github.com/XuehaiPan) in [#8](https://github.com/PKU-MARL/omnisafe/pull/8).
+- Add **Model-based Safe Algorithms:** `mbppolag`, `safeloop` by [@Weidong Huang](https://github.com/hdadong) in [#12](https://github.com/OmniSafeAI/omnisafe/pull/12).
+- Add .editorconfig and update license by [@XuehaiPan](https://github.com/XuehaiPan) in [#8](https://github.com/OmniSafeAI/omnisafe/pull/8).
 #### Fixes
-- Fix readme typo by [@erjanmx](https://github.com/erjanmx) in PR [#13](https://github.com/PKU-MARL/omnisafe/pull/13).
-- Fix ambiguous config yaml for algorithms by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#6](https://github.com/PKU-MARL/omnisafe/pull/6).
-- Fix vis `safety_gym_v2` with del the render_mode by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#3](https://github.com/PKU-MARL/omnisafe/pull/3).
+- Fix readme typo by [@erjanmx](https://github.com/erjanmx) in PR [#13](https://github.com/OmniSafeAI/omnisafe/pull/13).
+- Fix ambiguous config yaml for algorithms by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#6](https://github.com/OmniSafeAI/omnisafe/pull/6).
+- Fix vis `safety_gym_v2` with del the render_mode by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#3](https://github.com/OmniSafeAI/omnisafe/pull/3).
 
 #### Documentation
-- Refactor some code in omnisafe, add `CHANGELOG.md`,` and del install.md and tutorial in PR [#16](https://github.com/PKU-MARL/omnisafe/pull/16) by [@Jiaming Ji](https://github.com/zmsn-2077).
-- Docs: add `PCPO` in omnisafe's **docs** and modify `CPO` by [@Jiayi Zhou](https://github.com/Gaiejj) in [#9](https://github.com/PKU-MARL/omnisafe/pull/9).
-- Add `CPO` and `Intro` in omnisafe's **docs** by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#7](https://github.com/PKU-MARL/omnisafe/pull/7).
-- Add render mode and vision input in safety-gymnasium: `safety_gym_v2` by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#5](https://github.com/PKU-MARL/omnisafe/pull/5).
+- Refactor some code in omnisafe, add `CHANGELOG.md`,` and del install.md and tutorial in PR [#16](https://github.com/OmniSafeAI/omnisafe/pull/16) by [@Jiaming Ji](https://github.com/zmsn-2077).
+- Docs: add `PCPO` in omnisafe's **docs** and modify `CPO` by [@Jiayi Zhou](https://github.com/Gaiejj) in [#9](https://github.com/OmniSafeAI/omnisafe/pull/9).
+- Add `CPO` and `Intro` in omnisafe's **docs** by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#7](https://github.com/OmniSafeAI/omnisafe/pull/7).
+- Add render mode and vision input in safety-gymnasium: `safety_gym_v2` by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#5](https://github.com/OmniSafeAI/omnisafe/pull/5).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,31 +8,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 ### Features
+
 - Feat: add `ruff` and `codespell` integration by [@XuehaiPan](https://github.com/XuehaiPan) in PR [#186](https://github.com/OmniSafeAI/omnisafe/pull/186).
+
 ### Fixes
+
 ### Documentation
 
 
 
 ## v0.2.2
+
 ### Fixes
 - Add MANIFEST.in by [@Borong Zhang](https://github.com/muchvo) in PR [#182](https://github.com/OmniSafeAI/omnisafe/pull/182).
+
 ### Documentation
 - Update api documentation by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#181](https://github.com/OmniSafeAI/omnisafe/pull/181)
+
 ## v0.2.1
+
 ### Features
 - Feat(statistics tools): support statistics tools for experiments by [@Borong Zhang](https://github.com/muchvo) in PR [#157](https://github.com/OmniSafeAI/omnisafe/pull/157).
+
 ## v0.2.0
+
 ### Features
+
 - Support cuda by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#163](https://github.com/OmniSafeAI/omnisafe/pull/163).
 - Support command line interfaces for omnisafe by [@Borong Zhang](https://github.com/muchvo) in PR [#144](https://github.com/OmniSafeAI/omnisafe/pull/144).
 - Refactor(wrapper): refactor the cuda setting by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#176](https://github.com/OmniSafeAI/omnisafe/pull/176).
+
 ### Fixes
+
 - Fix(onpolicy_adapter): fix the calculation of last state value by [@Borong Zhang](https://github.com/muchvo) in PR [#164](https://github.com/OmniSafeAI/omnisafe/pull/164).
 - Fix(config.py): fix config assertion by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#174](https://github.com/OmniSafeAI/omnisafe/pull/174).
 - Fix autoreset wrapper in by [@r-y1](https://github.com/r-y1) PR [#167](https://github.com/OmniSafeAI/omnisafe/pull/167).
+
 ### Documentation
+
 - Update docs style by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#169](https://github.com/OmniSafeAI/omnisafe/pull/169).
 - Fix typo in readme by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#172](https://github.com/OmniSafeAI/omnisafe/pull/172).
 - Update README and the usage of CLI by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#138](https://github.com/OmniSafeAI/omnisafe/pull/138).
@@ -42,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Development
 ### 2023-03-06 ~ 2023-03-15
 #### Features
+
 - Chore(on-policy): update benchmark performance for first-order algorithms by [@Borong Zhang](https://github.com/muchvo) in PR [#148](https://github.com/OmniSafeAI/omnisafe/pull/148).
 - Feat(off-policy): add DDPG, TD3 SAC by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#128](https://github.com/OmniSafeAI/omnisafe/pull/128).
 - Feat: support policy evaluation by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#137](https://github.com/OmniSafeAI/omnisafe/pull/137).
@@ -50,127 +66,175 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Feat: update architecture of config.yaml by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#126](https://github.com/OmniSafeAI/omnisafe/pull/126).
 - Chore: support num_thread setting by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#124](https://github.com/OmniSafeAI/omnisafe/pull/124).
 - Refactor: change architecture of omnisafe by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#121](https://github.com/OmniSafeAI/omnisafe/pull/121).
+
 #### Fixes
+
 - Fix(on-policy): fix the second order algorithms performance by [@Jiayi Zhou](https://github.com/Gaiejj)  in PR [#147](https://github.com/OmniSafeAI/omnisafe/pull/147).
 - Fix(rollout, exp_grid): fix logdir path conflict by [@Borong Zhang](https://github.com/muchvo) in PR [#145](https://github.com/OmniSafeAI/omnisafe/pull/145).
 - Fix: support new config for exp_grid by [@Borong Zhang](https://github.com/muchvo) in PR [#142](https://github.com/OmniSafeAI/omnisafe/pull/142).
 - Fix(ppo): fix entropy loss by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#135](https://github.com/OmniSafeAI/omnisafe/pull/135).
 - Fix(algo): fix no return in algo_wrapper::learn by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#122](https://github.com/OmniSafeAI/omnisafe/pull/122).
+
 #### Documentation
 - Docs: Update changelog by [@Jiaming Ji](https://github.com/zmsn-2077).
 - Docs: Update README.md: fix action passing by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#149](https://github.com/OmniSafeAI/omnisafe/pull/149).
 - Chore: fix typo by [@1Asan](https://github.com/1Asan) in PR [#134](https://github.com/OmniSafeAI/omnisafe/pull/134).
+
 ### 2023-02-27 ~ 2023-03-05
 #### Fixes
+
 - Fix(P3O): fix P3O performance by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#123](https://github.com/OmniSafeAI/omnisafe/pull/123).
 - Fix(off-policy): fix `action passing` by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#119](https://github.com/OmniSafeAI/omnisafe/pull/119).
+
 #### Documentation
 - Docs: update logo by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#125](https://github.com/OmniSafeAI/omnisafe/pull/125).
 
 ### 2023-02-13 ~ 2023-02-19
+
 #### Fixes
+
 - Fix(evaluator): fix evaluator by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#117](https://github.com/OmniSafeAI/omnisafe/pull/117).
+
 ### 2023-02-06 ~ 2023-02-12
+
 #### Features
+
 - Build(env): delete local `safety-gymnaisum` dependence by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#102](https://github.com/OmniSafeAI/omnisafe/pull/102).
 - Refactor(buffer): refactor `buffer` by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#101](https://github.com/OmniSafeAI/omnisafe/pull/101).
 - Refactor: clean the code by [@Jiayi Zhou](https://github.com/Gaiejj) in
 #### Fixes
+
 - Fix: fix tools by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#100](https://github.com/OmniSafeAI/omnisafe/pull/100).
 - Fix: fix algo wrapper by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#99](https://github.com/OmniSafeAI/omnisafe/pull/99).
 PR [#97](https://github.com/OmniSafeAI/omnisafe/pull/97).
 #### Documentation
+
 - Modify `logo.png` and add `requirements.txt` by [@Ruiyang Sun](https://github.com/rockmagma02) in PR [#103](https://github.com/OmniSafeAI/omnisafe/pull/103).
 
 
 ### 2023-01-30 ~ 2023-02-05
+
 #### Features
+
 - Chore: update linter settings by [@XuehaiPan](https://github.com/XuehaiPan).
 - Chore: update ci  by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#90](https://github.com/OmniSafeAI/omnisafe/pull/90) reviewed by [@Jiaming Ji](https://github.com/zmsn-2077) and [@friedmainfunction](https://github.com/friedmainfunction).
 - Chore: update yaml  by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#92](https://github.com/OmniSafeAI/omnisafe/pull/92) and [#93](https://github.com/OmniSafeAI/omnisafe/pull/93) reviewed by [@Jiaming Ji](https://github.com/zmsn-2077) and [@friedmainfunction](https://github.com/friedmainfunction).
+
 ### 2023-01-23 ~ 2023-01-29
+
 #### Features
+
 - Refactor(objects): change object type into free_geom by [@Borong Zhang](https://github.com/muchvo) in PR [#89](https://github.com/OmniSafeAI/omnisafe/pull/89).
 - Chore: update algorithms configuration by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#88](https://github.com/OmniSafeAI/omnisafe/pull/88).
 - Feat: support cuda by [@Jiayi Zhou](https://github.com/Gaiejj in PR [#86](https://github.com/OmniSafeAI/omnisafe/pull/86).
 - Feat(render): add keyboard debug mode for some agents in all tasks by [@Borong Zhang](https://github.com/muchvo) in PR [#83](https://github.com/OmniSafeAI/omnisafe/pull/83).
 - Feat: add experiment grid by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#84](https://github.com/OmniSafeAI/omnisafe/pull/84).
+
 #### Fixes
+
 - Fix seed setting  by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#82](https://github.com/OmniSafeAI/omnisafe/pull/82).
 
 
 ### 2023-01-16 ~ 2023-01-22
+
 #### Features
+
 - Feat(agents): add `ant` agent by [@Borong Zhang](https://github.com/muchvo) in PR [#82](https://github.com/OmniSafeAI/omnisafe/pull/82).
 - Refactor(safety-gymnaisum): `code decoupling` by [@Borong Zhang](https://github.com/muchvo) in PR [#81](https://github.com/OmniSafeAI/omnisafe/pull/81).
 - Feat: add new algorithm by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#80](https://github.com/OmniSafeAI/omnisafe/pull/80).
+
 ### 2023-01-09 ~ 2023-01-15
+
 #### Features
+
 - Refactor: change wrapper setting by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#73](https://github.com/OmniSafeAI/omnisafe/pull/73).
 - Feat: `vectorized` environment by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#74](https://github.com/OmniSafeAI/omnisafe/pull/74).
 ### 2023-01-02 ~ 2023-01-08
+
 #### Features
+
 - Feat(agents, tasks, Evaluator): support `circle012` and new agent `racecar`, update evaluator by [@Borong Zhang](https://github.com/muchvo) in PR [#59](https://github.com/OmniSafeAI/omnisafe/pull/59).
 
 ### 2022-12-26 ~ 2023-01-01
+
 #### Features
+
 - Refactor: enhanced model-based code, add `CAP` algorithm by [@Weidong Huang](https://github.com/hdadong) in PR [#59](https://github.com/OmniSafeAI/omnisafe/pull/59).
 - Feat: support auto render as .mp4 videos, add examples and tests by [@Borong Zhang](https://github.com/muchvo) in PR [#60](https://github.com/OmniSafeAI/omnisafe/pull/60).
 #### Fixes
+
 - Fix(model-based): fix cap cost bug and lag beta value in cap.yaml by [@Weidong Huang](https://github.com/hdadong) in PR [#62](https://github.com/OmniSafeAI/omnisafe/pull/62).
 - Fix(render): fix markers are not shown in the rgb array returned by env.render() by [@Borong Zhang](https://github.com/muchvo) in PR [#61](https://github.com/OmniSafeAI/omnisafe/pull/61).
 
 
 
 ### 2022-12-19 ~ 2022-12-25
+
 #### Features
+
 - Feat(circle, run): support new tasks by [@Borong Zhang](https://github.com/muchvo) in PR [#50](https://github.com/OmniSafeAI/omnisafe/pull/50).
 - Add Makefile by [@XuehaiPan](https://github.com/XuehaiPan) in PR [#53](https://github.com/OmniSafeAI/omnisafe/pull/53).
 #### Fixes
+
 - Fix bug for namedtuple by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#54](https://github.com/OmniSafeAI/omnisafe/pull/54).
 #### Documentation
+
 - Fix spelling error by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#56](https://github.com/OmniSafeAI/omnisafe/pull/56), reviewed by [@Jiaming Ji](https://github.com/zmsn-2077) and [@XuehaiPan](https://github.com/XuehaiPan).
 
 
 ### 2022-12-12 ~ 2022-12-18
+
 #### Features
+
 - Refactor: open pylint in pre-commit by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#48](https://github.com/OmniSafeAI/omnisafe/pull/48).
 - Refactor: change the details and yaml files of on policy algorithm by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#41](https://github.com/OmniSafeAI/omnisafe/pull/41).
 - Feat: add CUP algorithm by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#43](https://github.com/OmniSafeAI/omnisafe/pull/43).
 - Feat(wrapper): separated wrapper for different algorithmic environments by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#44](https://github.com/OmniSafeAI/omnisafe/pull/44).
 - Chore: rename files and enable pylint by [@Borong Zhang](https://github.com/muchvo) in  PR [#39](https://github.com/OmniSafeAI/omnisafe/pull/39).
 #### Documentation
+
 - Retouch the formatting and add PPO docs for omnisafe by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#40](https://github.com/OmniSafeAI/omnisafe/pull/40).
 - Add Lagrangian method documentation by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#42](https://github.com/OmniSafeAI/omnisafe/pull/42).
 - Refactor(README): show the implemented algorithms in more detail by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#47](https://github.com/OmniSafeAI/omnisafe/pull/47).
 ### 2022-12-05 ~ 2022-12-11
+
 #### Features
+
 - Refactor: more OOP style code were used and made better code and file structure by [@Borong Zhang](https://github.com/muchvo) in PR [#37](https://github.com/OmniSafeAI/omnisafe/pull/37).
 - Refactor: change the file layout of omnisafe by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#35](https://github.com/OmniSafeAI/omnisafe/pull/35).
 #### Fixes
+
 - Fix(env_wrapper): fix warning caused by 'none' string default value by [@Borong Zhang](https://github.com/muchvo) in PR [#30](https://github.com/OmniSafeAI/omnisafe/pull/30).
 #### Documentation
+
 - Docs: retouch the formatting and add links to the formula numbers by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#31](https://github.com/OmniSafeAI/omnisafe/pull/31).
 ### 2022-11-28 ~ 2022-12-04
+
 #### Features
+
 - Chore(.github): update issue templates by [@XuehaiPan](https://github.com/XuehaiPan) in PR [#29](https://github.com/OmniSafeAI/omnisafe/pull/29).
 - Refactor packaging by [@XuehaiPan](https://github.com/XuehaiPan) in PR [#20](https://github.com/OmniSafeAI/omnisafe/pull/20).
 - Add ddpg, clean some code, modify algo_wrapper in PR [#24](https://github.com/OmniSafeAI/omnisafe/pull/24) by [@Jiaming Ji](https://github.com/zmsn-2077).
 #### Documentation
+
 - Add `TRPO` to docs by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#28](https://github.com/OmniSafeAI/omnisafe/pull/28).
 - Add `FOCOPS` and `PCPO` to docs by [@XuehaiPan](https://github.com/XuehaiPan) in [#21](https://github.com/OmniSafeAI/omnisafe/pull/21).
 
 ### 2022-11-20 ~ 2022-11-27
+
 #### Features
+
 - Add render_mode: `human`, `rgb_array`, `depth_array` in safety-gymnasium: `safety_gym_v2`.
 - Add **Model-based Safe Algorithms:** `mbppolag`, `safeloop` by [@Weidong Huang](https://github.com/hdadong) in [#12](https://github.com/OmniSafeAI/omnisafe/pull/12).
 - Add .editorconfig and update license by [@XuehaiPan](https://github.com/XuehaiPan) in [#8](https://github.com/OmniSafeAI/omnisafe/pull/8).
 #### Fixes
+
 - Fix readme typo by [@erjanmx](https://github.com/erjanmx) in PR [#13](https://github.com/OmniSafeAI/omnisafe/pull/13).
 - Fix ambiguous config yaml for algorithms by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#6](https://github.com/OmniSafeAI/omnisafe/pull/6).
 - Fix vis `safety_gym_v2` with del the render_mode by [@Jiaming Ji](https://github.com/zmsn-2077) in PR [#3](https://github.com/OmniSafeAI/omnisafe/pull/3).
 
 #### Documentation
+
 - Refactor some code in omnisafe, add `CHANGELOG.md`,` and del install.md and tutorial in PR [#16](https://github.com/OmniSafeAI/omnisafe/pull/16) by [@Jiaming Ji](https://github.com/zmsn-2077).
 - Docs: add `PCPO` in omnisafe's **docs** and modify `CPO` by [@Jiayi Zhou](https://github.com/Gaiejj) in [#9](https://github.com/OmniSafeAI/omnisafe/pull/9).
 - Add `CPO` and `Intro` in omnisafe's **docs** by [@Jiayi Zhou](https://github.com/Gaiejj) in PR [#7](https://github.com/OmniSafeAI/omnisafe/pull/7).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,11 @@ into two categories:
     - Create an issue about your intended feature, and we shall discuss the design and
     implementation. Once we agree that the plan looks good, go ahead and implement it.
 2. You want to implement a feature or bug-fix for an outstanding issue
-    - Look at the outstanding issues here: https://github.com/PKU-MARL/omnisafe/issues
+    - Look at the outstanding issues here: https://github.com/OmniSafeAI/omnisafe/issues
     - Pick an issue or feature and comment on the task that you want to work on this feature.
     - If you need more context on a particular issue, please ask and we shall provide.
 
-Once you finish implementing a feature or bug-fix, please send a Pull Request to https://github.com/PKU-MARL/omnisafe
+Once you finish implementing a feature or bug-fix, please send a Pull Request to https://github.com/OmniSafeAI/omnisafe
 
 If you are not familiar with creating a Pull Request, here are some guides:
 
@@ -25,7 +25,7 @@ To develop OmniSafe on your machine, here are some tips:
 1. Clone a copy of OmniSafe from GitHub:
 
 ```bash
-git clone https://github.com/PKU-MARL/omnisafe
+git clone https://github.com/OmniSafeAI/omnisafe
 cd omnisafe/
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 <!-- markdownlint-disable html -->
 
 <div align="center">
-  <img src="https://github.com/PKU-MARL/omnisafe/raw/HEAD/images/logo.png" width="75%"/>
+  <img src="https://github.com/OmniSafeAI/omnisafe/raw/HEAD/images/logo.png" width="75%"/>
 </div>
 
 <div align="center">
 
-  [![Organization](https://img.shields.io/badge/Organization-PKU_MARL-blue.svg)](https://github.com/PKU-MARL)
+  [![Organization](https://img.shields.io/badge/Organization-PKU_MARL-blue.svg)](https://github.com/OmniSafeAI)
   [![PyPI](https://img.shields.io/pypi/v/omnisafe?logo=pypi)](https://pypi.org/project/omnisafe)
   [![tests](https://img.shields.io/github/actions/workflow/status/PKU-MARL/omnisafe/test.yml?label=tests&logo=github)](https://github.com/OmniSafeAI/omnisafe/tree/HEAD/tests)
   [![Documentation Status](https://img.shields.io/readthedocs/omnisafe?logo=readthedocs)](https://omnisafe.readthedocs.io)
   [![Downloads](https://static.pepy.tech/personalized-badge/omnisafe?period=total&left_color=grey&right_color=blue&left_text=downloads)](https://pepy.tech/project/omnisafe)
-  [![GitHub Repo Stars](https://img.shields.io/github/stars/PKU-MARL/omnisafe?color=brightgreen&logo=github)](https://github.com/PKU-MARL/OmniSafe/stargazers)
+  [![GitHub Repo Stars](https://img.shields.io/github/stars/OmniSafeAI/omnisafe?color=brightgreen&logo=github)](https://github.com/OmniSafeAI/OmniSafe/stargazers)
   [![codestyle](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
   [![License](https://img.shields.io/github/license/PKU-MARL/OmniSafe?label=license)](#license)
   [![CodeCov](https://img.shields.io/codecov/c/github/PKU-MARL/omnisafe/main?logo=codecov)](https://app.codecov.io/gh/PKU-MARL/omnisafe)
@@ -22,10 +22,10 @@
 
 <p align="center">
   <a href="https://omnisafe.readthedocs.io">Documentation</a> |
-  <a href="https://github.com/PKU-MARL/omnisafe#implemented-algorithms">Implemented Algorithms</a> |
-  <a href="https://github.com/PKU-MARL/omnisafe#installation">Installation</a> |
-  <a href="https://github.com/PKU-MARL/omnisafe#getting-started">Getting Started</a> |
-  <a href="https://github.com/PKU-MARL/omnisafe#license">License</a>
+  <a href="https://github.com/OmniSafeAI/omnisafe#implemented-algorithms">Implemented Algorithms</a> |
+  <a href="https://github.com/OmniSafeAI/omnisafe#installation">Installation</a> |
+  <a href="https://github.com/OmniSafeAI/omnisafe#getting-started">Getting Started</a> |
+  <a href="https://github.com/OmniSafeAI/omnisafe#license">License</a>
 </p>
 
 --------------------------------------------------------------------------------
@@ -140,7 +140,7 @@ OmniSafe requires Python 3.8+ and PyTorch 1.10+.
 
 ```bash
 # Clone the repo
-git clone https://github.com/PKU-MARL/omnisafe
+git clone https://github.com/OmniSafeAI/omnisafe
 cd omnisafe
 
 # Create a conda environment
@@ -226,7 +226,7 @@ More information about environments, please refer to [Safety Gymnasium](https://
 
 **A video example**
 
-![Segmentfault](https://github.com/PKU-MARL/omnisafe/blob/main/images/CLI_example.svg)
+![Segmentfault](https://github.com/OmniSafeAI/omnisafe/blob/main/images/CLI_example.svg)
 
 ```bash
 pip install omnisafe
@@ -268,11 +268,11 @@ We take great pleasure in collaborating with our users to create tutorials in va
 --------------------------------------------------------------------------------
 
 ## Changelog
-See [CHANGELOG.md](https://github.com/PKU-MARL/omnisafe/blob/main/CHANGELOG.md).
+See [CHANGELOG.md](https://github.com/OmniSafeAI/omnisafe/blob/main/CHANGELOG.md).
 
 ## The OmniSafe Team
 
-OmniSafe is mainly developed by the SafeRL research team directed by Prof. [Yaodong Yang](https://github.com/orgs/PKU-MARL/people/PKU-YYang). Our SafeRL research team members include [Borong Zhang](https://github.com/muchvo), [Jiayi Zhou](https://github.com/Gaiejj), [JTao Dai](https://github.com/calico-1226), [Weidong Huang](https://github.com/hdadong), [Ruiyang Sun](https://github.com/rockmagma02), [Xuehai Pan](https://github.com/XuehaiPan) and [Jiaming Ji](https://github.com/zmsn-2077). If you have any questions in the process of using omnisafe, don't hesitate to ask your questions on [the GitHub issue page](https://github.com/PKU-MARL/omnisafe/issues/new/choose), we will reply to you in 2-3 working days.
+OmniSafe is mainly developed by the SafeRL research team directed by Prof. [Yaodong Yang](https://github.com/orgs/OmniSafeAI/people/PKU-YYang). Our SafeRL research team members include [Borong Zhang](https://github.com/muchvo), [Jiayi Zhou](https://github.com/Gaiejj), [JTao Dai](https://github.com/calico-1226), [Weidong Huang](https://github.com/hdadong), [Ruiyang Sun](https://github.com/rockmagma02), [Xuehai Pan](https://github.com/XuehaiPan) and [Jiaming Ji](https://github.com/zmsn-2077). If you have any questions in the process of using omnisafe, don't hesitate to ask your questions on [the GitHub issue page](https://github.com/OmniSafeAI/omnisafe/issues/new/choose), we will reply to you in 2-3 working days.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -263,8 +263,6 @@ Explore OmniSafe easily and quickly through a series of colab notebooks:
 
 We take great pleasure in collaborating with our users to create tutorials in various languages. Please refer to our list of currently supported languages. If you are interested in translating the tutorial into a new language or improving an existing version, kindly submit a PR to us."
 
-
-
 --------------------------------------------------------------------------------
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 
   [![Organization](https://img.shields.io/badge/Organization-PKU_MARL-blue.svg)](https://github.com/OmniSafeAI)
   [![PyPI](https://img.shields.io/pypi/v/omnisafe?logo=pypi)](https://pypi.org/project/omnisafe)
-  [![tests](https://img.shields.io/github/actions/workflow/status/PKU-MARL/omnisafe/test.yml?label=tests&logo=github)](https://github.com/OmniSafeAI/omnisafe/tree/HEAD/tests)
+  [![tests](https://img.shields.io/github/actions/workflow/status/OmniSafeAI/omnisafe/test.yml?label=tests&logo=github)](https://github.com/OmniSafeAI/omnisafe/tree/HEAD/tests)
   [![Documentation Status](https://img.shields.io/readthedocs/omnisafe?logo=readthedocs)](https://omnisafe.readthedocs.io)
   [![Downloads](https://static.pepy.tech/personalized-badge/omnisafe?period=total&left_color=grey&right_color=blue&left_text=downloads)](https://pepy.tech/project/omnisafe)
   [![GitHub Repo Stars](https://img.shields.io/github/stars/OmniSafeAI/omnisafe?color=brightgreen&logo=github)](https://github.com/OmniSafeAI/OmniSafe/stargazers)
   [![codestyle](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-  [![License](https://img.shields.io/github/license/PKU-MARL/OmniSafe?label=license)](#license)
-  [![CodeCov](https://img.shields.io/codecov/c/github/PKU-MARL/omnisafe/main?logo=codecov)](https://app.codecov.io/gh/PKU-MARL/omnisafe)
-  [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PKU-MARL/omnisafe/)
+  [![License](https://img.shields.io/github/license/OmniSafeAI/OmniSafe?label=license)](#license)
+  [![CodeCov](https://img.shields.io/codecov/c/github/OmniSafeAI/omnisafe/main?logo=codecov)](https://app.codecov.io/gh/OmniSafeAI/omnisafe)
+  [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/OmniSafeAI/omnisafe/)
 
 </div>
 
@@ -258,8 +258,8 @@ omnisafe train-config ./saved_source/train_config.yaml
 
 ### Quickstart: Colab in the Cloud
 Explore OmniSafe easily and quickly through a series of colab notebooks:
-- [Getting Started](https://colab.research.google.com/github/PKU-MARL/omnisafe/blob/main/tutorials/English/1.Getting_Started.ipynb) Introduce the basic usage of OmniSafe so that users can quickly hand on it.
-- [CLI Command](https://colab.research.google.com/github/PKU-MARL/omnisafe/blob/main/tutorials/English/2.CLI_Command.ipynb) Introduce how to use the CLI tool of OmniSafe.
+- [Getting Started](https://colab.research.google.com/github/OmniSafeAI/omnisafe/blob/main/tutorials/English/1.Getting_Started.ipynb) Introduce the basic usage of OmniSafe so that users can quickly hand on it.
+- [CLI Command](https://colab.research.google.com/github/OmniSafeAI/omnisafe/blob/main/tutorials/English/2.CLI_Command.ipynb) Introduce how to use the CLI tool of OmniSafe.
 
 We take great pleasure in collaborating with our users to create tutorials in various languages. Please refer to our list of currently supported languages. If you are interested in translating the tutorial into a new language or improving an existing version, kindly submit a PR to us."
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,7 +23,7 @@ The OmniSafe Mujoco Velocity Benchmark assesses the efficacy of OmniSafe's SafeR
 - **[ICML 2017]** [Proximal Constrained Policy Optimization (PCPO)](https://proceedings.mlr.press/v70/achiam17a)
 - **[ICLR 2019]** [Reward Constrained Policy Optimization (RCPO)](https://openreview.net/forum?id=SkfrvsA9FX)
 
-> **More details can be refer to [On Policy Experiment](https://github.com/PKU-MARL/omnisafe/tree/main/benchmarks/on-policy/README.md).**
+> **More details can be refer to [On Policy Experiment](https://github.com/OmniSafeAI/omnisafe/tree/main/benchmarks/on-policy/README.md).**
 
 ## Off-Policy
 ### Supported Algorithms
@@ -31,4 +31,4 @@ The OmniSafe Mujoco Velocity Benchmark assesses the efficacy of OmniSafe's SafeR
 - [Twin Delayed DDPG (TD3)](https://arxiv.org/pdf/1802.09477.pdf)
 - [Soft Actor-Critic (SAC)](https://arxiv.org/pdf/1812.05905.pdf)
 
-> **More details can be refer to [Off Policy Experiment](https://github.com/PKU-MARL/omnisafe/tree/main/benchmarks/off-policy/README.md).**
+> **More details can be refer to [Off Policy Experiment](https://github.com/OmniSafeAI/omnisafe/tree/main/benchmarks/off-policy/README.md).**

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,7 +74,7 @@ html_copy_source = False
 html_context = {
     'conf_py_path': '/docs/',
     'display_github': False,
-    'github_user': 'PKU-MARL',
+    'github_user': 'OmniSafeAI',
     'github_repo': 'OmniSafe',
     'github_version': 'main',
     'slug': 'omnisafe',

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -292,10 +292,10 @@ You may not yet understand the above theory and the specific meaning of the code
 Long-Term Support and Support History
 -------------------------------------
 
-**OmniSafe** is mainly developed by the SafeRL research team directed by `Prof. Yaodong Yang <https://github.com/orgs/PKU-MARL/people/PKU-YYang>`_,
+**OmniSafe** is mainly developed by the SafeRL research team directed by `Prof. Yaodong Yang <https://github.com/orgs/OmniSafeAI/people/PKU-YYang>`_,
 Our SafeRL research team members include `Borong Zhang <https://github.com/muchvo>`_ , `Jiayi Zhou <https://github.com/Gaiejj>`_, `JTao Dai <https://github.com/calico-1226>`_,  `Weidong Huang <https://github.com/hdadong>`_, `Ruiyang Sun <https://github.com/rockmagma02>`_, `Xuehai Pan <https://github.com/XuehaiPan>`_ and `Jiamg Ji <https://github.com/zmsn-2077>`_.
 If you have any questions in the process of using OmniSafe, or if you are willing to contribute to
-this project, don't hesitate to ask your question on `the GitHub issue page <https://github.com/PKU-MARL/omnisafe/issues/new/choose>`_, we will reply to you in 2-3 working days.
+this project, don't hesitate to ask your question on `the GitHub issue page <https://github.com/OmniSafeAI/omnisafe/issues/new/choose>`_, we will reply to you in 2-3 working days.
 
 ------
 

--- a/docs/source/start/installation.rst
+++ b/docs/source/start/installation.rst
@@ -16,7 +16,7 @@ You can also install OmniSafe from source:
 
 .. code-block:: bash
 
-    $ git clone https://github.com/PKU-MARL/omnisafe.git
+    $ git clone https://github.com/OmniSafeAI/omnisafe.git
     $ cd omnisafe
     $ conda create -n omnisafe python=3.8
     $ conda activate omnisafe

--- a/docs/source/start/usage.rst
+++ b/docs/source/start/usage.rst
@@ -69,7 +69,7 @@ Customize Configuration
         <script async id="asciicast-qCptIXhxYB2MWEytijrriVhUm" src="https://asciinema.org/a/qCptIXhxYB2MWEytijrriVhUm.js"></script>
 
 .. hint::
-    The above command will use a configuration file `train_config.yaml <https://github.com/PKU-MARL/omnisafe/blob/main/tests/saved_source/train_config.yaml>`_ in the `saved_source <https://github.com/PKU-MARL/omnisafe/tree/main/tests/saved_source>`_ directory to train policy. We have provided an example showing the file layer of the configuration file. You can customize the configuration of the algorithm in this file.
+    The above command will use a configuration file `train_config.yaml <https://github.com/OmniSafeAI/omnisafe/blob/main/tests/saved_source/train_config.yaml>`_ in the `saved_source <https://github.com/OmniSafeAI/omnisafe/tree/main/tests/saved_source>`_ directory to train policy. We have provided an example showing the file layer of the configuration file. You can customize the configuration of the algorithm in this file.
 
 Run Benchmark
 -------------
@@ -93,7 +93,7 @@ Run Benchmark
         <script async id="asciicast-gg6edB7OWiFENACpQzpfgFRx6" src="https://asciinema.org/a/gg6edB7OWiFENACpQzpfgFRx6.js"></script>
 
 .. hint::
-    The above command will run a benchmark with 2 CPU threads. The configuration file `benchmark_config.yaml <https://github.com/PKU-MARL/omnisafe/blob/main/tests/saved_source/benchmark_config.yaml>`_ is in the `saved_source <https://github.com/PKU-MARL/omnisafe/tree/main/tests/saved_source>`_ directory. We have provided an example showing the file layer of the configuration file. You can customize the configuration of the benchmark in this file.
+    The above command will run a benchmark with 2 CPU threads. The configuration file `benchmark_config.yaml <https://github.com/OmniSafeAI/omnisafe/blob/main/tests/saved_source/benchmark_config.yaml>`_ is in the `saved_source <https://github.com/OmniSafeAI/omnisafe/tree/main/tests/saved_source>`_ directory. We have provided an example showing the file layer of the configuration file. You can customize the configuration of the benchmark in this file.
 
 Run Evaluation
 --------------
@@ -117,7 +117,7 @@ Run Evaluation
         <script async id="asciicast-UbRWY6EI6Nl7R27Lk3Rpk4HI5" src="https://asciinema.org/a/UbRWY6EI6Nl7R27Lk3Rpk4HI5.js"></script>
 
 .. hint::
-    The above command will run an evaluation with 2 CPU threads. The model parameters is in the `saved_source <https://github.com/PKU-MARL/omnisafe/tree/main/tests/saved_source>`_ directory.
+    The above command will run an evaluation with 2 CPU threads. The model parameters is in the `saved_source <https://github.com/OmniSafeAI/omnisafe/tree/main/tests/saved_source>`_ directory.
 
 Get Help
 --------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,10 @@ dependencies = [
 dynamic = ["version", "entry-points"]
 
 [project.urls]
-Homepage = "https://github.com/PKU-MARL/omnisafe"
-Repository = "https://github.com/PKU-MARL/omnisafe"
+Homepage = "https://github.com/OmniSafeAI/omnisafe"
+Repository = "https://github.com/OmniSafeAI/omnisafe"
 Documentation = "https://omnisafe.readthedocs.io"
-"Bug Report" = "https://github.com/PKU-MARL/omnisafe/issues"
+"Bug Report" = "https://github.com/OmniSafeAI/omnisafe/issues"
 
 [project.optional-dependencies]
 lint = [

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ try:
         author='OmniSafe Team',
         author_email='jiamg.ji@gmail.com',
         description='OmniSafe is an infrastructural framework for accelerating SafeRL research.',
-        url='https://github.com/PKU-MARL/omnisafe',
+        url='https://github.com/OmniSafeAI/omnisafe',
         entry_points={'console_scripts': ['omnisafe=omnisafe.utils.command_app:app']},
         packages=setuptools.find_namespace_packages(
             include=['omnisafe', 'omnisafe.*'],

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -7,6 +7,6 @@ At present, our tutorials are available in the following languages, and you can 
 - [Getting Started](https://colab.research.google.com/github/OmniSafeAI/omnisafe/blob/main/tutorials/English/1.Getting_Started.ipynb) Introduce the basic usage of OmniSafe so that users can quickly hand on it.
 - [CLI Command](https://colab.research.google.com/github/OmniSafeAI/omnisafe/blob/main/tutorials/English/2.CLI_Command.ipynb) Introduce how to use the CLI tool of OmniSafe.
 
-## 简体中文
+## Zh-CN
 - [Getting Started](https://colab.research.google.com/github/OmniSafeAI/omnisafe/blob/main/tutorials/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87/1.Getting%20Started.ipynb) 介绍OmniSafe的基本用法，使用户能够快速上手。
 - [CLI Command](https://colab.research.google.com/github/OmniSafeAI/omnisafe/blob/main/tutorials/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87/2.CLI%20Command.ipynb) 介绍如何使用OmniSafe的命令行工具。

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -4,9 +4,9 @@
 At present, our tutorials are available in the following languages, and you can access them via Colab:
 
 ## English
-- [Getting Started](https://colab.research.google.com/github/PKU-MARL/omnisafe/blob/main/tutorials/English/1.Getting_Started.ipynb) Introduce the basic usage of OmniSafe so that users can quickly hand on it.
-- [CLI Command](https://colab.research.google.com/github/PKU-MARL/omnisafe/blob/main/tutorials/English/2.CLI_Command.ipynb) Introduce how to use the CLI tool of OmniSafe.
+- [Getting Started](https://colab.research.google.com/github/OmniSafeAI/omnisafe/blob/main/tutorials/English/1.Getting_Started.ipynb) Introduce the basic usage of OmniSafe so that users can quickly hand on it.
+- [CLI Command](https://colab.research.google.com/github/OmniSafeAI/omnisafe/blob/main/tutorials/English/2.CLI_Command.ipynb) Introduce how to use the CLI tool of OmniSafe.
 
 ## 简体中文
-- [Getting Started](https://colab.research.google.com/github/PKU-MARL/omnisafe/blob/main/tutorials/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87/1.Getting%20Started.ipynb) 介绍OmniSafe的基本用法，使用户能够快速上手。
-- [CLI Command](https://colab.research.google.com/github/PKU-MARL/omnisafe/blob/main/tutorials/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87/2.CLI%20Command.ipynb) 介绍如何使用OmniSafe的命令行工具。
+- [Getting Started](https://colab.research.google.com/github/OmniSafeAI/omnisafe/blob/main/tutorials/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87/1.Getting%20Started.ipynb) 介绍OmniSafe的基本用法，使用户能够快速上手。
+- [CLI Command](https://colab.research.google.com/github/OmniSafeAI/omnisafe/blob/main/tutorials/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87/2.CLI%20Command.ipynb) 介绍如何使用OmniSafe的命令行工具。


### PR DESCRIPTION
## Description

Because of migrating the repo from the organization `PKU-MARL` to `OmniSafeAI`, we need to update the links in it.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/PKU-MARL/omnisafe/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://omnisafe.readthedocs.io/en/latest/developer/contributing.html) guide. (**required**)
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format`. (**required**)
- [ ] I have checked the code using `make lint`. (**required**)
- [ ] I have ensured `make test` pass. (**required**)
